### PR TITLE
32 complete additional metrics for trend following

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ This mirror exists to:
 ## 🔗 Related Skills
 
 - **Frontend**: React, ECharts, SCSS
-- **Backend**: Node.js, WebSocket, REST API's
+- **Backend**: Node.js, WebSocket, REST APIs
 - **Tooling**: Vite, Git, GitHub Actions, ESLint
 - **Testing**: Vitest, Jest, React Testing Library

--- a/src/components/candlestick/candlestick-config.ts
+++ b/src/components/candlestick/candlestick-config.ts
@@ -21,10 +21,12 @@ export const options = {
       obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 30
       return obj
     },
-    formatter: params => {
+    formatter: (params: any[]) => {
       const candle = params.find(p => p.seriesType === 'candlestick')
       const extended = params.find(p => p.seriesName === 'Extended Tick Data')
       const ADX = params.find(p => p.seriesName === 'ADX')
+      const RSI = params.find(p => p.seriesName === 'RSI')
+
       // console.log(ADX)
 
       // console.log(params)
@@ -55,6 +57,7 @@ export const options = {
         smaPercentSlopeByPeriod: ${extended.data.smaSlopeByPeriod}<br/>
         emaPercentSlopeByPeriod: ${extended.data.emaSlopeByPeriod}<br/>
         ADX: ${ADX.data}<br/>
+        RSI: ${RSI.data}<br/>
         emaCrossing: ${extended.data.emaCrossing.crossing}<br/>
         emaCrossingDirection: ${extended.data.emaCrossing.direction}<br/>
         bollingerBreakout: ${extended.data.bollingerBreakout}<br/>

--- a/src/components/candlestick/candlestick-config.ts
+++ b/src/components/candlestick/candlestick-config.ts
@@ -78,9 +78,10 @@ export const options = {
     },
   },
   toolbox: {
+    show: false,
     feature: {
       dataZoom: {
-        yAxisIndex: false,
+        yAxisIndex: true,
       },
       brush: {
         type: ['lineX', 'clear'],
@@ -98,7 +99,12 @@ export const options = {
     show: true,
     seriesIndex: 1,
     dimension: 2,
-    bottom: '23%',
+    top: '0%',
+    left: '4px',
+    textStyle: {
+      color: '#00729b',
+      padding: 0,
+    },
     pieces: [
       {
         value: -1,
@@ -114,21 +120,32 @@ export const options = {
   },
   grid: [
     {
-      left: '10%',
-      right: '8%',
-      height: '40%',
+      // Candlestick
+      top: '1%',
+      left: '200px',
+      right: '15px',
+      height: '60%',
     },
     {
-      left: '10%',
-      right: '8%',
-      top: '53%',
-      height: '12%',
+      // Volume
+      left: '200px',
+      right: '15px',
+      top: '41%',
+      height: '20%',
     },
     {
-      left: '10%',
-      right: '8%',
-      top: '70%',
+      // ADX, RSI
+      left: '200px',
+      right: '15px',
+      top: '65%',
       height: '10%',
+    },
+    {
+      // MACD
+      left: '200px',
+      right: '15px',
+      top: '75%',
+      height: '20%',
     },
   ],
   yAxis: [
@@ -137,6 +154,7 @@ export const options = {
       splitArea: {
         show: true,
       },
+      boundaryGap: ['25%', '4%'],
     },
     {
       scale: true,
@@ -156,6 +174,15 @@ export const options = {
       axisTick: { show: false },
       splitLine: { show: false },
     },
+    {
+      scale: true,
+      gridIndex: 3,
+      splitNumber: 2,
+      axisLabel: { show: false },
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { show: false },
+    },
   ],
   dataZoom: [
     {
@@ -165,17 +192,12 @@ export const options = {
     },
     {
       show: true,
-      xAxisIndex: [0, 1, 2],
+      xAxisIndex: [0, 1, 2, 3],
       type: 'slider',
       filterMode: 'weakFilter',
-      top: '85%',
+      top: '96.5%',
+      height: '20px',
+      left: '197px',
     },
-    // {
-    //   show: true,
-    //   xAxisIndex: [0, 1, 2],
-    //   type: 'slider',
-    //   filterMode: 'weakFilter',
-    //   top: '85%',
-    // },
   ],
 }

--- a/src/components/candlestick/candlestick-config.ts
+++ b/src/components/candlestick/candlestick-config.ts
@@ -55,9 +55,9 @@ export const options = {
         smaPercentSlopeByPeriod: ${extended.data.smaSlopeByPeriod}<br/>
         emaPercentSlopeByPeriod: ${extended.data.emaSlopeByPeriod}<br/>
         ADX: ${ADX.data}<br/>
-
-
-
+        emaCrossing: ${extended.data.emaCrossing.crossing}<br/>
+        emaCrossingDirection: ${extended.data.emaCrossing.direction}<br/>
+        bollingerBreakout: ${extended.data.bollingerBreakout}<br/>
       `
           : ''
       }

--- a/src/components/candlestick/candlestick-config.ts
+++ b/src/components/candlestick/candlestick-config.ts
@@ -61,6 +61,9 @@ export const options = {
         emaCrossing: ${extended.data.emaCrossing.crossing}<br/>
         emaCrossingDirection: ${extended.data.emaCrossing.direction}<br/>
         bollingerBreakout: ${extended.data.bollingerBreakout}<br/>
+        volumeTrendIncreasing: ${extended.data.volumeTrendIncreasing}<br/>
+        bearishEngulfScore: ${extended.data.bearishEngulfingScore}<br/>
+        bullishExhaustion: ${extended.data.isBullishExhaustion}<br/>
       `
           : ''
       }

--- a/src/components/candlestick/candlestick-service.tsx
+++ b/src/components/candlestick/candlestick-service.tsx
@@ -249,6 +249,18 @@ export const buildOptions = (dataOptions: BuildOptionsArgsType): unknown => {
           color: '#a6a254',
         },
       },
+      {
+        name: 'RSI',
+        symbolSize: 1,
+        xAxisIndex: 2,
+        yAxisIndex: 2,
+        data: dataOptions.analysisData.analysis.RSI,
+        type: 'line',
+        smooth: true,
+        itemStyle: {
+          color: 'green',
+        },
+      },
     )
   }
 

--- a/src/components/candlestick/candlestick-service.tsx
+++ b/src/components/candlestick/candlestick-service.tsx
@@ -39,8 +39,9 @@ export const buildOptions = (dataOptions: BuildOptionsArgsType): unknown => {
 
   const legend = [
     {
-      bottom: 10,
-      left: 'center',
+      top: '50px',
+      width: '110px',
+      left: 0,
       selected: dataOptions.legendData ? dataOptions.legendData.current?.selected : { 'Single Direction': false },
       data: [
         {
@@ -52,7 +53,7 @@ export const buildOptions = (dataOptions: BuildOptionsArgsType): unknown => {
           // icon: '',
         },
       ],
-      backgroundColor: '#222',
+      // backgroundColor: '#222',
       textStyle: {
         color: '#00729b',
         padding: 0,
@@ -261,6 +262,52 @@ export const buildOptions = (dataOptions: BuildOptionsArgsType): unknown => {
           color: 'green',
         },
       },
+      {
+        name: 'MACD',
+        symbolSize: 1,
+        xAxisIndex: 3,
+        yAxisIndex: 3,
+        data: dataOptions.analysisData.analysis.MACD.macdLine,
+        type: 'line',
+        smooth: true,
+        itemStyle: {
+          color: 'green',
+        },
+      },
+      {
+        name: 'MACD Signal',
+        symbolSize: 1,
+        xAxisIndex: 3,
+        yAxisIndex: 3,
+        data: dataOptions.analysisData.analysis.MACD.signalLine,
+        type: 'line',
+        smooth: true,
+        itemStyle: {
+          color: 'yellow',
+        },
+        lineStyle: {
+          type: 'dashed',
+        },
+      },
+      {
+        name: 'MACD Histogram',
+        type: 'bar',
+        xAxisIndex: 3,
+        yAxisIndex: 3,
+        data: dataOptions.analysisData.analysis.MACD.histogram,
+        itemStyle: {
+          color: (params: any) => (params.value >= 0 ? '#4ade80' : '#f87171'), // green/red
+        },
+        markLine: {
+          silent: true,
+          data: [{ yAxis: 0 }],
+          lineStyle: {
+            color: '#888',
+            type: 'dashed',
+            width: 1,
+          },
+        },
+      },
     )
   }
 
@@ -292,6 +339,18 @@ export const buildOptions = (dataOptions: BuildOptionsArgsType): unknown => {
     {
       type: 'category',
       gridIndex: 2,
+      data: dataOptions.chartData?.categoryData,
+      boundaryGap: false,
+      axisLine: { onZero: false },
+      axisTick: { show: false },
+      splitLine: { show: false },
+      axisLabel: { show: false },
+      min: 'dataMin',
+      max: 'dataMax',
+    },
+    {
+      type: 'category',
+      gridIndex: 3,
       data: dataOptions.chartData?.categoryData,
       boundaryGap: false,
       axisLine: { onZero: false },

--- a/src/components/candlestick/candlestick.component.tsx
+++ b/src/components/candlestick/candlestick.component.tsx
@@ -54,7 +54,7 @@ export const Candlestick: React.FC<CandleStickProps> = (props: CandleStickProps)
   const legendRef = useRef<Partial<echarts.LegendComponentOption> | null>(null)
   const zoomTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const extendedTickDataRef = useRef<any>(null)
-  const extendedTickDataHovered = useRef<any>(null)
+  // const extendedTickDataHovered = useRef<any>(null)
 
   const onDataZoom = (params: echarts.DataZoomComponentOption) => {
     if (zoomTimeoutRef.current) {
@@ -170,7 +170,7 @@ export const Candlestick: React.FC<CandleStickProps> = (props: CandleStickProps)
         socketControls={props.socketControls}
         clearChart={clearChart}
       />
-      {extendedTickDataRef ? (
+      {/* {extendedTickDataRef ? (
         <div
           style={{
             position: 'absolute',
@@ -183,7 +183,7 @@ export const Candlestick: React.FC<CandleStickProps> = (props: CandleStickProps)
           <br />
           <span>{extendedTickDataHovered?.current?.isWickCrossing}</span>
         </div>
-      ) : null}
+      ) : null} */}
 
       {options ? (
         <ReactECharts

--- a/src/components/request/algo-params/algo-params.tsx
+++ b/src/components/request/algo-params/algo-params.tsx
@@ -274,6 +274,37 @@ export const AlgoParams: React.FC = () => {
           title={''}
         />
       </div>
+
+      <div className="param-section-wrapper macd">
+        <h3>MACD Periods</h3>
+        <LabeledNumberInput
+          label="MACD Short Period"
+          name="algoParam_macdShortPeriod"
+          min={1}
+          max={100}
+          step={1}
+          defaultValue={12}
+          title={''}
+        />
+        <LabeledNumberInput
+          label="MACD Long Period"
+          name="algoParam_macdLongPeriod"
+          min={1}
+          max={100}
+          step={1}
+          defaultValue={26}
+          title={''}
+        />
+        <LabeledNumberInput
+          label="MACD Signal Period"
+          name="algoParam_macdSignalPeriod"
+          min={1}
+          max={100}
+          step={1}
+          defaultValue={9}
+          title={''}
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/request/algo-params/algo-params.tsx
+++ b/src/components/request/algo-params/algo-params.tsx
@@ -204,6 +204,19 @@ export const AlgoParams: React.FC = () => {
         />
       </div>
 
+      <div className="param-section-wrapper single-dir">
+        <h3>Confirmation Indicators</h3>
+        <LabeledNumberInput
+          label="RSI Period"
+          name="algoParam_rsiPeriod"
+          min={0}
+          max={100}
+          step={1}
+          defaultValue={14}
+          title={''}
+        />
+      </div>
+
       {
         // Crossing algo
         // candleBodyDistribution

--- a/src/components/request/algo-params/algo-params.tsx
+++ b/src/components/request/algo-params/algo-params.tsx
@@ -305,6 +305,59 @@ export const AlgoParams: React.FC = () => {
           title={''}
         />
       </div>
+
+      <div className="param-section-wrapper volumeTrend">
+        <h3>Volume Trend</h3>
+        <LabeledNumberInput
+          label="Volume Trend Lookback"
+          name="algoParam_volumeTrendLookback"
+          min={1}
+          max={100}
+          step={1}
+          defaultValue={5}
+          title={''}
+        />
+        <LabeledNumberInput
+          label="Volume Min Trend"
+          name="algoParam_volumeTrendMinTrend"
+          min={0}
+          max={3}
+          step={0.01}
+          defaultValue={0.65}
+          title={''}
+        />
+        <LabeledNumberInput
+          label="Volume Trend Min Surge"
+          name="algoParam_volumeTrendMinSurge"
+          min={0}
+          max={5}
+          step={0.01}
+          defaultValue={1.2}
+          title={''}
+        />
+      </div>
+
+      <div className="param-section-wrapper bearish-bullish-candle-signals">
+        <h3>Candle Signals</h3>
+        <LabeledNumberInput
+          label="Bearish Engulfish Tolerance"
+          name="algoParam_bearEngTolerance"
+          min={0}
+          max={1}
+          step={0.001}
+          defaultValue={0.005}
+          title={''}
+        />
+        <LabeledNumberInput
+          label="Bullish Exhaustion Threshold"
+          name="algoParam_bullExhThreshold"
+          min={1}
+          max={5}
+          step={0.1}
+          defaultValue={2}
+          title={''}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes private Issue#32

Adds params, inputs, and chart display for the following metrics:
- EMACrossover
- BollingerBreakout
- RSI
- MACD
- Experimental VolumeTrend metrics (ongoing WIP - see backend for notes)

Updates tooltip logic for charts.

Updates README